### PR TITLE
Enable windows kernel tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,4 +40,4 @@ install:
 build_script:
   - cd test
   - test_xeus_cling
-  - cd.. && cd.. && cd test && py.test . & exit 0
+  - cd.. && cd.. && cd test && py.test .


### PR DESCRIPTION
Windows failures appear to be related to `jupyter_kernel_test`. All requests fail with:

```
_________________________ XCppTests.test_kernel_info __________________________
self = <test_xcpp_kernel.XCppTests testMethod=test_kernel_info>
    def test_kernel_info(self):
        self.flush_channels()
    
        msg_id = self.kc.kernel_info()
>       reply = self.kc.get_shell_msg(timeout=TIMEOUT)
C:\xeus-conda\lib\site-packages\jupyter_kernel_test\__init__.py:43: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
C:\xeus-conda\lib\site-packages\jupyter_client\client.py:77: in get_shell_msg
    return self.shell_channel.get_msg(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
self = <jupyter_client.blocking.channels.ZMQSocketChannel object at 0x000001A1FD32D088>
block = True, timeout = 15000
    def get_msg(self, block=True, timeout=None):
        """ Gets a message if there is one that is ready. """
        if block:
            if timeout is not None:
                timeout *= 1000  # seconds to ms
            ready = self.socket.poll(timeout)
        else:
            ready = self.socket.poll(timeout=0)
    
        if ready:
            return self._recv()
        else:
>           raise Empty
E           _queue.Empty
C:\xeus-conda\lib\site-packages\jupyter_client\blocking\channels.py:57: Empty
```