### PR TITLE
Add wrapper functions to redirect printf and fprintf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,7 @@ set(XEUS_CLING_SRC
     src/xmagics/os.cpp
     src/xmagics/os.hpp
     src/xmime_internal.hpp
+    src/xredirect.cpp
 )
 
 # xeus-cling headers

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -28,6 +28,9 @@
 
 using namespace std::placeholders;
 
+// the global variable enables redirection in printf and fprintf
+extern bool c_io_redirect;
+
 namespace xcpp
 {
     void interpreter::configure_impl()
@@ -308,12 +311,16 @@ namespace xcpp
 
         std::cout.rdbuf(&m_cout_buffer);
         std::cerr.rdbuf(&m_cerr_buffer);
+
+	c_io_redirect = true;
     }
 
     void interpreter::restore_output()
     {
         std::cout.rdbuf(p_cout_strbuf);
         std::cerr.rdbuf(p_cerr_strbuf);
+
+	c_io_redirect = false;
     }
 
     void interpreter::publish_stdout(const std::string& s)

--- a/src/xredirect.cpp
+++ b/src/xredirect.cpp
@@ -1,0 +1,71 @@
+/***********************************************************************************
+* Copyright (c) 2016, Johan Mabille, Loic Gouarin, Sylvain Corlay, Wolf Vollprecht *
+* Copyright (c) 2016, QuantStack                                                   *
+*                                                                                  *
+* Distributed under the terms of the BSD 3-Clause License.                         *
+*                                                                                  *
+* The full license is in the file LICENSE, distributed with this software.         *
+************************************************************************************/
+
+#include <iostream>
+#include <vector>
+
+bool c_io_redirect = false;
+
+int redirect_output(FILE * __restrict stream, const char *__restrict format, va_list args)
+{
+    // Determine the length of the formatted string
+    va_list args_length;
+    va_copy(args_length, args);
+    const int length = vsnprintf(nullptr, 0, format, args_length);
+    va_end(args_length);
+    const int buffer_size = length + 1;
+    std::vector<char> buffer(buffer_size);
+    vsnprintf(buffer.data(), buffer_size, format, args);
+    va_end(args);
+
+    if (stream == stdout)
+    {
+        std::cout << buffer.data();
+	return length;
+    }
+    else if (stream == stderr)
+    {
+        std::cerr << buffer.data();
+        return length;
+    }
+    else
+    {
+        return vfprintf(stream, format, args);
+    }
+}
+
+int printf ( const char *__restrict format, ... )
+{
+    va_list args;
+    va_start(args, format);
+
+    if (c_io_redirect)
+    {
+        return redirect_output(stdout, format, args);
+    }
+    else
+    {
+        return vprintf(format, args);
+    }
+}
+
+int fprintf(FILE *__restrict stream, const char *__restrict format, ...)
+{
+    va_list args;
+    va_start(args, format);
+
+    if (c_io_redirect)
+    {
+        return redirect_output(stream, format, args);
+    }
+    else
+    {
+        return vfprintf(stream,format, args);
+    }
+}

--- a/src/xredirect.cpp
+++ b/src/xredirect.cpp
@@ -9,6 +9,7 @@
 
 #include <iostream>
 #include <vector>
+#include <stdarg.h>
 
 bool c_io_redirect = false;
 


### PR DESCRIPTION
# About
- the C functions printf and fprintf are reimplemented to allow
redirection to the web browser output
- if redirection is not enabled, the output is printed to the default
stdout and stderr (normally the terminal output)
- other C streams than stdout and stderr are not affected

It address the Issue #112 

# Design Issue

Currently I use a global variable to enable and disable redirection in printf and fprintf. Because of the C function signature I have not found a better solution. Maybe you have a better idea. It is also possible to remove the redirection variable in general and redirect the output to the C++ output every time.