### PR TITLE
Add help_links to kernel_info_reply

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -292,6 +292,11 @@ namespace xcpp
         result["language_info"]["mimetype"] = "text/x-c++src";
         result["language_info"]["codemirror_mode"] = "text/x-c++src";
         result["language_info"]["file_extension"] = ".cpp";
+        result["help_links"] = nl::json::array();
+        result["help_links"][0] = nl::json::object({
+            {"text", "Xeus-Cling Reference"},
+            {"url", "https://xeus-cling.readthedocs.io"}
+        });
         result["status"] = "ok";
         return result;
     }


### PR DESCRIPTION
Similar to https://github.com/jupyter-xeus/xeus-python/pull/211.

![xeus-cling-help-links](https://user-images.githubusercontent.com/591645/76851597-d42f6a80-6849-11ea-886a-c9062eeb81ed.gif)
