### PR TITLE
Fix build with non-standard LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ set(LLVM_MAIN_INCLUDE_DIR ${INCLUDE_DIR} CACHE PATH "Path to llvm/include")
 set(LLVM_BINARY_DIR ${LLVM_OBJ_ROOT} CACHE PATH "Path to LLVM build tree")
 set(LLVM_MAIN_SRC_DIR ${MAIN_SRC_DIR} CACHE PATH "Path to LLVM source tree")
 
+include_directories(${LLVM_MAIN_INCLUDE_DIR})
 link_directories(${LLVM_LIBRARY_DIR})
 add_definitions(-DLLVM_DIR="${LLVM_BINARY_DIR}")
 


### PR DESCRIPTION
When LLVM and Cling are installed into a non-standard path, the build
system needs to make sure that the include files are found.