### PR TITLE
%%executable: Parse options for code generation

### DIFF
--- a/docs/source/magics.rst
+++ b/docs/source/magics.rst
@@ -47,6 +47,14 @@ with `-l` to link extra libraries that have otherwise been loaded with
 
     #pragma cling load("...")
 
+Furthermore some options influence code generation:
+
++-------------------+---------------------------------------------+
+| -fsanitize=thread | enable instrumentation with ThreadSanitizer |
++-------------------+---------------------------------------------+
+| -g                | enable debug information in the executable  |
++-------------------+---------------------------------------------+
+
 %%file
 ------
 

--- a/src/xmagics/executable.hpp
+++ b/src/xmagics/executable.hpp
@@ -32,7 +32,7 @@ namespace xcpp
 
         std::string generate_fns(const std::string& cell, std::string& main,
                                  std::string& unique_fn);
-        bool generate_obj(std::string& ObjectFile);
+        bool generate_obj(std::string& ObjectFile, bool EnableDebugInfo);
         bool generate_exe(const std::string& ObjectFile,
                           const std::string& ExeFile,
                           const std::vector<std::string>& LinkerOptions);


### PR DESCRIPTION
This searches for select linker options that should also have an effect on code generation:
 * `-fsanitize=thread` for instrumentation with ThreadSanitizer, and
 * `-g` for debug information.

Note that this performs exact string comparisons. Ideally the parsing would use mechanisms provided by LLVM and Clang, but in particular the `SanitizerArgs` expect a `ToolChain` which we don't have in xeus-cling.