### PR TITLE
Fixes for Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,33 +307,35 @@ if(MSVC)
     )
 
     set(cling_exports ${cling_exports}
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEAPEBD@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEAPEBX@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBC@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBD@Z 
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBE@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBF@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBG@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBH@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBI@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBJ@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBK@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBM@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBN@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBO@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBQEBD@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBV23@@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBV?$$basic_string@_SU?$$char_traits@_S@std@@V?$$allocator@_S@2@@3@@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBV?$$basic_string@_UU?$$char_traits@_U@std@@V?$$allocator@_U@2@@3@@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBV?$$basic_string@_WU?$$char_traits@_W@std@@V?$$allocator@_W@2@@3@@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBVValue@1@@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBX@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEB_J@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEB_K@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEB_N@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEB_S@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEB_U@Z
-        ?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEB_W@Z
+        ?printValue@cling@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEBH@Z
+        ?printValue@cling@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEBX@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEAPEBD@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEAPEBX@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBC@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBD@Z 
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBE@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBF@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBG@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBH@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBI@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBJ@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBK@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBM@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBN@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBO@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBQEBD@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBV23@@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBV?$$basic_string@_SU?$$char_traits@_S@std@@V?$$allocator@_S@2@@3@@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBV?$$basic_string@_UU?$$char_traits@_U@std@@V?$$allocator@_U@2@@3@@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBV?$$basic_string@_WU?$$char_traits@_W@std@@V?$$allocator@_W@2@@3@@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBVValue@1@@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEBX@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEB_J@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEB_K@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEB_N@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEB_S@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEB_U@Z
+        #?printValue@cling@@YA?AV?$$basic_string@DU?$$char_traits@D@std@@V?$$allocator@D@2@@std@@PEB_W@Z
     )
 
     if($<CONFIG:Debug>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ add_definitions(-DLLVM_DIR="${LLVM_BINARY_DIR}")
 # Dependencies #
 ################
 
-set(xeus_REQUIRED_VERSION 0.21.1)
+set(xeus_REQUIRED_VERSION 0.23.1)
 set(cppzmq_REQUIRED_VERSION 4.3.0)
 
 find_package(xeus ${xeus_REQUIRED_VERSION} REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,16 @@ target_include_directories(xeus-cling
                            PUBLIC
                            $<BUILD_INTERFACE:${XEUS_CLING_INCLUDE_DIR}>
                            $<INSTALL_INTERFACE:include>)
-target_link_libraries(xeus-cling PUBLIC clingInterpreter clingMetaProcessor clingUtils xeus pugixml cxxopts::cxxopts)
+target_link_libraries(xeus-cling
+                      PUBLIC
+                      xeus
+
+                      PRIVATE
+                      clingInterpreter
+                      clingMetaProcessor
+                      clingUtils
+                      pugixml
+                      cxxopts::cxxopts)
 
 set_target_properties(xeus-cling PROPERTIES
                       PUBLIC_HEADER "${XEUS_CLING_HEADERS}"

--- a/README.md
+++ b/README.md
@@ -32,21 +32,41 @@ conda install xeus-cling -c conda-forge
 ```
 
 ### Installation from source
+You have to clone the repository at first and create the folder to build the sources:
 
-You will first need to create a new environment and install the dependencies:
+```bash
+git clone https://github.com/jupyter-xeus/xeus-cling
+```
 
+#### Specfic Instructions for Unix Based Systems (Linux, Mac OS X...)
+You need to create a new environment and install the dependencies:
 ```bash
 conda create -n xeus-cling -c conda-forge cmake xeus=0.23.3 cling=0.6.0 clangdev=5.0 llvmdev=5 nlohmann_json cppzmq=4.3.0 xtl=0.6.9 pugixml cxxopts=2.1.1
 conda activate xeus-cling
 ```
 
 You can then compile the sources:
-
 ```bash
+mkdir build && cd build
 cmake -D CMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -D CMAKE_C_COMPILER=$CC -D CMAKE_CXX_COMPILER=$CXX -D CMAKE_INSTALL_LIBDIR=${CONDA_PREFIX}/lib -D DOWNLOAD_GTEST=ON
-make && make install
+cmake --build . --target INSTALL
 ```
 
+#### Specific Instructions for Visual Studio 2015 (Windows)
+You need to create a new environment and install the dependencies:
+```bash
+conda create -n xeus-cling -c conda-forge cmake xeus=0.23.3 cling=0.6.0 clangdev=5.0 llvmdev=5 nlohmann_json cppzmq=4.3.0 xtl=0.6.9 pugixml cxxopts=2.1.1 dirent
+conda activate xeus-cling
+```
+
+You can then compile the sources:
+```bash
+mkdir build && cd build
+cmake -D CMAKE_INSTALL_PREFIX="%CONDA_PREFIX%" CMAKE_INSTALL_LIBDIR="%CONDA_PREFIX%/lib" -D DOWNLOAD_GTEST=ON -G"Visual Studio 14 Win64" ..
+cmake --build . --target INSTALL --config Release
+```
+
+#### Frontend Installation
 If you don't have a frontend already installed (classic Jupyter Notebook or JupyterLab for instance), install one:
 
 ```bash

--- a/include/xeus-cling/xinterpreter.hpp
+++ b/include/xeus-cling/xinterpreter.hpp
@@ -16,17 +16,6 @@
 #include <string>
 #include <vector>
 
-#if defined(WIN32)
-#pragma warning(push, 0)
-#endif
-
-#include "cling/Interpreter/Interpreter.h"
-#include "cling/MetaProcessor/MetaProcessor.h"
-
-#if defined(WIN32)
-#pragma warning(pop)
-#endif
-
 #include "nlohmann/json.hpp"
 
 #include "xeus/xinterpreter.hpp"
@@ -34,6 +23,12 @@
 #include "xeus_cling_config.hpp"
 #include "xbuffer.hpp"
 #include "xmanager.hpp"
+
+namespace cling
+{
+class Interpreter;
+class MetaProcessor;
+}
 
 namespace nl = nlohmann;
 
@@ -85,8 +80,8 @@ namespace xcpp
 
         std::string get_stdopt(int argc, const char* const* argv);
 
-        cling::Interpreter m_cling;
-        cling::MetaProcessor m_processor;
+        cling::Interpreter* m_cling;
+        cling::MetaProcessor* m_processor;
         std::string m_version;
 
         xmagics_manager xmagics;

--- a/include/xeus-cling/xinterpreter.hpp
+++ b/include/xeus-cling/xinterpreter.hpp
@@ -16,8 +16,16 @@
 #include <string>
 #include <vector>
 
+#if defined(WIN32)
+#pragma warning(push, 0)
+#endif
+
 #include "cling/Interpreter/Interpreter.h"
 #include "cling/MetaProcessor/MetaProcessor.h"
+
+#if defined(WIN32)
+#pragma warning(pop)
+#endif
 
 #include "nlohmann/json.hpp"
 

--- a/share/jupyter/kernels/xcpp11/kernel.json.in
+++ b/share/jupyter/kernels/xcpp11/kernel.json.in
@@ -4,7 +4,9 @@
       "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/xcpp",
       "-f",
       "{connection_file}",
-      "-std=c++11"
+      "-std=c++11",
+      "-I",
+      "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/../Library/include"
   ],
   "language": "C++11"
 }

--- a/share/jupyter/kernels/xcpp14/kernel.json.in
+++ b/share/jupyter/kernels/xcpp14/kernel.json.in
@@ -4,7 +4,9 @@
       "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/xcpp",
       "-f",
       "{connection_file}",
-      "-std=c++14"
+      "-std=c++14",
+      "-I",
+      "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/../Library/include"
   ],
   "language": "C++14"
 }

--- a/share/jupyter/kernels/xcpp17/kernel.json.in
+++ b/share/jupyter/kernels/xcpp17/kernel.json.in
@@ -4,7 +4,9 @@
       "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/xcpp",
       "-f",
       "{connection_file}",
-      "-std=c++17"
+      "-std=c++17",
+      "-I",
+      "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/../Library/include"
   ],
   "language": "C++17"
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,9 +13,16 @@
 #include <utility>
 
 #include "xeus/xkernel.hpp"
-#include "xeus/xkernel_configuration.hpp"
+#if defined(max)
+#undef max
+#endif
+#if defined(min)
+#undef min
+#endif
 
 #include "xeus-cling/xinterpreter.hpp"
+
+#include "xeus/xkernel_configuration.hpp"
 
 std::string extract_filename(int& argc, char* argv[])
 {

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -15,7 +15,16 @@
 #include <sstream>
 #include <vector>
 
+#if defined(WIN32)
+#pragma warning(push, 0)
+#endif
+
 #include "llvm/Support/DynamicLibrary.h"
+
+#if defined(WIN32)
+#pragma warning(pop)
+#endif
+
 #include "xeus-cling/xbuffer.hpp"
 #include "xeus-cling/xeus_cling_config.hpp"
 #include "xeus-cling/xinterpreter.hpp"

--- a/src/xmagics/executable.cpp
+++ b/src/xmagics/executable.cpp
@@ -15,6 +15,10 @@
 #include <string>
 #include <vector>
 
+#if defined(WIN32)
+#pragma warning(push, 0)
+#endif
+
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Module.h"
@@ -33,6 +37,10 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "cling/Interpreter/Interpreter.h"
 #include "cling/Interpreter/Transaction.h"
+
+#if defined(WIN32)
+#pragma warning(pop)
+#endif
 
 #include "xeus-cling/xoptions.hpp"
 

--- a/src/xmagics/execution.cpp
+++ b/src/xmagics/execution.cpp
@@ -123,7 +123,7 @@ namespace xcpp
             {
                 for (std::size_t n = 0; n < 10; ++n)
                 {
-                    number = std::pow(10, n);
+                    number = static_cast<size_t>(std::pow(10, n));
                     std::string timeit_code = inner(number, code);
                     indent = m_processor->process(timeit_code.c_str(), compilation_result, &output);
                     if (output.simplisticCastAs<double>() >= 0.2)

--- a/src/xmime_internal.hpp
+++ b/src/xmime_internal.hpp
@@ -16,6 +16,10 @@
 
 #include "nlohmann/json.hpp"
 
+#if defined(WIN32)
+#pragma warning(push, 0)
+#endif
+
 #include "cling/Interpreter/Exception.h"
 #include "cling/Interpreter/CValuePrinter.h"
 #include "cling/Interpreter/Interpreter.h"
@@ -37,6 +41,10 @@
 #include "llvm/ExecutionEngine/GenericValue.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
+
+#if defined(WIN32)
+#pragma warning(pop)
+#endif
 
 namespace nl = nlohmann;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,6 +64,11 @@ if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
 
     # Add googletest directly to our build. This defines
     # the gtest and gtest_main targets.
+    
+    if(MSVC)
+        set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    endif()
+    
     add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
                      ${CMAKE_CURRENT_BINARY_DIR}/googletest-build EXCLUDE_FROM_ALL)
 

--- a/test/downloadGTest.cmake.in
+++ b/test/downloadGTest.cmake.in
@@ -13,7 +13,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
     GIT_REPOSITORY    https://github.com/google/googletest.git
-    GIT_TAG           release-1.8.0
+    GIT_TAG           release-1.10.0
     SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
     BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
I guess there needs more work to be done as C++11 currently doesn't work. Moreover the exported symbols from cling produce a lot of issues. I will try to build cling on my own to see what is going wrong.

First tests seem to work now under Windows.
![grafik](https://user-images.githubusercontent.com/6927011/78500394-6397b180-7756-11ea-976a-8f4dc1e46a6b.png)

To Dos:
- ~Update Readme.md with proper steps for Windows~
- Try to avoid the exported functions workaround from cling
- Fix printf as it currently only outputs strings to the running console of Jupyter Lab and is not forwared to the web based IDE
- Fix C++11 issue
```
In file included from input_line_1:1:
In file included from C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include\new:6:
In file included from C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include\exception:8:
In file included from C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include\type_traits:6:
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include\xstddef:338:2: error: 'auto' return without trailing return type; deduced return types are a C++14 extension
```
