### PR TITLE
xmagics: Add default value for filename

### DIFF
--- a/src/xmagics/executable.cpp
+++ b/src/xmagics/executable.cpp
@@ -46,7 +46,8 @@ namespace xcpp
     {
         xoptions options{"executable", "write executable"};
         options.add_options()
-            ("f,filename", "filename", cxxopts::value<std::string>())
+            ("f,filename", "filename",
+             cxxopts::value<std::string>()->default_value(""))
             ("o,options", "options",
              cxxopts::value<std::vector<std::string>>()->default_value(""));
         options.parse_positional({"filename", "options"});

--- a/src/xmagics/os.cpp
+++ b/src/xmagics/os.cpp
@@ -25,7 +25,8 @@ namespace xcpp
         xoptions options{"file", "write file"};
         options.add_options()
             ("a,append", "append")
-            ("f,filename", "filename", cxxopts::value<std::string>());
+            ("f,filename", "filename",
+             cxxopts::value<std::string>()->default_value(""));
         options.parse_positional("filename");
         return options;
     }


### PR DESCRIPTION
This avoids exceptions when the user omits the option completely and
correctly outputs the error message that the parameter is required.