### PR TITLE
Fix off-by-one in c_format for printf()

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -312,7 +312,8 @@ namespace xcpp
 
     static std::string c_format(const char* format, std::va_list args)
     {
-        // Call vsnprintf once to determine the required buffer length.
+        // Call vsnprintf once to determine the required buffer length. The
+        // return value is the number of characters _excluding_ the null byte.
         std::va_list args_bufsz;
         va_copy(args_bufsz, args);
         size_t bufsz = vsnprintf(NULL, 0, format, args_bufsz);
@@ -324,7 +325,9 @@ namespace xcpp
         // Now format the data into this string and return it.
         std::va_list args_format;
         va_copy(args_format, args);
-        vsnprintf(&s[0], s.size(), format, args_format);
+        // The second parameter is the maximum number of bytes that vsnprintf
+        // will write _including_ the  terminating null byte.
+        vsnprintf(&s[0], s.size() + 1, format, args_format);
         va_end(args_format);
 
         return s;


### PR DESCRIPTION
The return value of vsnprintf is the number of characters _excluding_
the null byte, while the second parameter is the maximum number of
bytes that vsnprintf will write _including_ the  terminating null byte.