### PR TITLE
Extra interpreter setup from cling.cpp

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -53,6 +53,16 @@ namespace xcpp
           m_cout_buffer(std::bind(&interpreter::publish_stdout, this, _1)),
           m_cerr_buffer(std::bind(&interpreter::publish_stderr, this, _1))
     {
+        // Extra setup normally performed in Cling's main function
+        m_cling.AddIncludePath(".");
+
+        // Load libs
+        const cling::InvocationOptions& Opts = m_cling.getOptions();
+        for (const std::string& Lib : Opts.LibsToLoad)
+        {
+          m_cling.loadFile(Lib);
+        }
+
         redirect_output();
         init_preamble();
         init_magic();


### PR DESCRIPTION
There are currently two steps performed in Cling's main function that don't get performed in `xeus-cling`, because `xeus-cling`  uses Cling as a library rather than use Cling's normal driver.

One is to step through the `Opts.LibsToLoad` options and load libraries. Without this step, `xeus-cling` doesn't respect the `-l` flag.

The other is to run `m_cling.AddIncludePath(".")`. I don't feel as strongly about this one, but Cling does it and it seems like a good idea.

See here: https://github.com/root-project/cling/blob/e84dc544fc25bda635948c56335a989f39957ebc/tools/driver/cling.cpp#L103