### PR TITLE
executable: Check that function has an identifier

### DIFF
--- a/src/xmagics/executable.cpp
+++ b/src/xmagics/executable.cpp
@@ -96,10 +96,15 @@ namespace xcpp
 
         bool VisitFunctionDecl(clang::FunctionDecl* D)
         {
-            if (!D->getName().startswith("__cling"))
+            // Filter out functions added by Cling.
+            if (auto Identifier = D->getIdentifier())
             {
-                m_consumer->HandleTopLevelDecl(clang::DeclGroupRef(D));
+                if (Identifier->getName().startswith("__cling"))
+                {
+                    return true;
+                }
             }
+            m_consumer->HandleTopLevelDecl(clang::DeclGroupRef(D));
             return true;
         }
 


### PR DESCRIPTION
In order to call `getName()`, the `FunctionDecl` must have an identifier. This only poses a problem when enabling asserts, otherwise the code in `getName()` already protects against `getIdentifier()` giving `nullptr` and returns the empty string.