### PR TITLE
Avoid injecting template to ADL

### DIFF
--- a/include/xcpp/xdisplay.hpp
+++ b/include/xcpp/xdisplay.hpp
@@ -18,32 +18,11 @@ namespace nl = nlohmann;
 
 namespace xcpp
 {
-    // concept check wheather T has a mime_bundle_repr overload
-    // defalut case: mime_bundle_repr overload does fail
-    template<class T, class = void>
-    struct has_mime_bundle_repr
-        : public std::false_type
-    {};
-
-    // specialized case (SFINAE): mime_bundle_repr overload does not fail
-    template<class T>
-    struct has_mime_bundle_repr<T,std::void_t<decltype(mime_bundle_repr(std::declval<T>()))>>
-        : std::true_type
-    {};
-
-    template<class T>
-    nl::json dispatch_bundle_repr(T&& t) {
-        if constexpr (has_mime_bundle_repr<T>{})
-            return mime_bundle_repr(std::forward<T>(t));
-        else
-            return fallback_mime_bundle_repr(std::forward<T>(t));
-    }
-    
     template <class T>
     void display(T&& t)
     {
         xeus::get_interpreter().display_data(
-            dispatch_bundle_repr(std::forward<T>(t)),
+            dispatch_mime_bundle_repr(std::forward<T>(t)),
             nl::json::object(),
             nl::json::object()
         );
@@ -57,7 +36,7 @@ namespace xcpp
         if (update)
         {
             xeus::get_interpreter().update_display_data(
-                dispatch_bundle_repr(std::forward<T>(t)),
+                dispatch_mime_bundle_repr(std::forward<T>(t)),
                 nl::json::object(),
                 std::move(transient)
             );
@@ -65,7 +44,7 @@ namespace xcpp
         else
         {
             xeus::get_interpreter().display_data(
-                dispatch_bundle_repr(std::forward<T>(t)),
+                dispatch_mime_bundle_repr(std::forward<T>(t)),
                 nl::json::object(),
                 std::move(transient)
             );

--- a/include/xcpp/xmime.hpp
+++ b/include/xcpp/xmime.hpp
@@ -43,7 +43,7 @@ namespace xcpp
 
     // Default implementation of mime_bundle_repr
     template <class T>
-    nl::json mime_bundle_repr(const T& value)
+    nl::json fallback_mime_bundle_repr(const T& value)
     {
         auto bundle = nl::json::object();
         bundle["text/plain"] = cling::printValue(&value);
@@ -52,14 +52,14 @@ namespace xcpp
 
     // Implementation for std::complex.
     template <class T>
-    nl::json mime_bundle_repr(const std::complex<T>& value)
+    nl::json fallback_mime_bundle_repr(const std::complex<T>& value)
     {
         return detail::mime_bundle_repr_via_sstream(value);
     }
 
     // Implementation for long double. This is a workaround for
     // https://github.com/jupyter-xeus/xeus-cling/issues/220
-    inline nl::json mime_bundle_repr(const long double& value)
+    inline nl::json fallback_mime_bundle_repr(const long double& value)
     {
         return detail::mime_bundle_repr_via_sstream(value);
     }

--- a/include/xcpp/xmime.hpp
+++ b/include/xcpp/xmime.hpp
@@ -63,6 +63,28 @@ namespace xcpp
     {
         return detail::mime_bundle_repr_via_sstream(value);
     }
+
+    // concept check wheather T has a mime_bundle_repr overload
+    // default case: mime_bundle_repr overload does fail
+    template<class T, class = void>
+    struct has_mime_bundle_repr
+        : public std::false_type
+    {};
+
+    // specialized case (SFINAE): mime_bundle_repr overload does not fail
+    template<class T>
+    struct has_mime_bundle_repr<T,std::void_t<decltype(mime_bundle_repr(std::declval<T>()))>>
+        : std::true_type
+    {};
+
+    template<class T>
+    nl::json dispatch_mime_bundle_repr(T&& t) {
+        if constexpr (has_mime_bundle_repr<T>{})
+            return mime_bundle_repr(std::forward<T>(t));
+        else
+            return fallback_mime_bundle_repr(std::forward<T>(t));
+    }
+
 }
 
 #endif

--- a/src/xmime_internal.hpp
+++ b/src/xmime_internal.hpp
@@ -191,8 +191,7 @@ namespace xcpp
         {
             // Use an llvm::raw_ostream to prepend '0x' in front of the pointer value.
             cling::ostrstream code;
-            code << "using xcpp::mime_bundle_repr;";
-            code << "mime_bundle_repr(";
+            code << "xcpp::dispatch_mime_bundle_repr(";
             code << "*(" << xcpp::cling_detail::getTypeString(V);
             code << &value;
             code << "));";


### PR DESCRIPTION
The current default implementation of `mime_bundle_repr` injects a template to the Argument Dependent Lookup. This is very inconvenient because the user may also want to also provide a templated function. Unfortunately, this will fail in the overload resolution stage because of ambiguity (see https://godbolt.org/z/n9xxE44TW). Therefore (based on https://godbolt.org/z/Gsr1fq6TM), I propose a concept check that test if the user provided her own `mime_bundle_repr` and if so dispatch it to the display data, otherwise, call the fallback implementation.