### PR TITLE
Correct installation instructions from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ mamba install xeus-cling -c conda-forge
 You will first need to create a new environment and install the dependencies:
 
 ```bash
-mamba create -n xeus-cling -c conda-forge cmake xeus=1.0.0 cling=0.8 clangdev=5.0 llvmdev=5 nlohmann_json cppzmq xtl pugixml cxxopts
+mamba create -n xeus-cling -c conda-forge cmake "xeus>=2.0,<3.0" cling=0.8 clangdev=5.0.0 llvmdev=5 "nlohmann_json>=3.9.1,<3.10" "cppzmq>=4.6.0,<5" "xtl>=0.7,<0.8" pugixml "cxxopts>=2.1.1,<2.2"
 source activate xeus-cling
 ```
 


### PR DESCRIPTION
The package versions in the given `mamba install` command are not matching the current requirements as specified in the feedstock: https://github.com/conda-forge/xeus-cling-feedstock/blob/master/recipe/meta.yaml#L30 The PR replicates the feedstock information in the README.