### PR TITLE
Don't install into /usr/etc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,8 +400,13 @@ install(DIRECTORY ${XCPP_TAGCONFS_DIR}
         DESTINATION ${XEUS_CLING_CONF_DIR})
 
 # Add definitions for the kernel to find tagfiles.
-add_definitions(-DXCPP_TAGFILES_DIR="${XEUS_CLING_DATA_DIR}/tagfiles")
-add_definitions(-DXCPP_TAGCONFS_DIR="${XEUS_CLING_CONF_DIR}/tags.d")
+add_definitions(-DXCPP_TAGFILES_DIR="${CMAKE_INSTALL_PREFIX}/${XEUS_CLING_DATA_DIR}/tagfiles")
+if(CMAKE_INSTALL_PREFIX STREQUAL "/usr")
+    # install into /etc instead of /usr/etc
+    add_definitions(-DXCPP_TAGCONFS_DIR="/${XEUS_CLING_CONF_DIR}/tags.d")
+else()
+    add_definitions(-DXCPP_TAGCONFS_DIR="${CMAKE_INSTALL_PREFIX}/${XEUS_CLING_CONF_DIR}/tags.d")
+endif()
 
 # Makes the project importable from the build directory
 export(EXPORT ${PROJECT_NAME}-targets

--- a/src/xinspect.hpp
+++ b/src/xinspect.hpp
@@ -21,8 +21,6 @@
 
 #include "pugixml.hpp"
 
-#include "xtl/xsystem.hpp"
-
 #include "xeus-cling/xbuffer.hpp"
 #include "xeus-cling/xpreamble.hpp"
 
@@ -171,8 +169,8 @@ namespace xcpp
 
     void inspect(const std::string& code, nl::json& kernel_res, cling::Interpreter& interpreter)
     {
-        std::string tagconf_dir = xtl::prefix_path() + XCPP_TAGCONFS_DIR;
-        std::string tagfiles_dir = xtl::prefix_path() + XCPP_TAGFILES_DIR;
+        std::string tagconf_dir = XCPP_TAGCONFS_DIR;
+        std::string tagfiles_dir = XCPP_TAGFILES_DIR;
 
         nl::json tagconfs = read_tagconfs(tagconf_dir.c_str());
 


### PR DESCRIPTION
According to §4.9.3 of the Filesystem Hierarchy Standard:

"Note that /usr/etc is still not allowed: programs in /usr should place
configuration files in /etc."