### PR TITLE
Add custom `help` for magic commands

### DIFF
--- a/include/xeus-cling/xoptions.hpp
+++ b/include/xeus-cling/xoptions.hpp
@@ -14,6 +14,8 @@
 
 #include <argparse/argparse.hpp>
 
+#include "xeus-cling/xeus_cling_config.hpp"
+
 namespace xcpp
 {
     struct argparser : public argparse::ArgumentParser

--- a/src/xmagics/executable.cpp
+++ b/src/xmagics/executable.cpp
@@ -44,7 +44,7 @@ namespace xcpp
 {
     argparser executable::get_options()
     {
-        argparser argpars("executable");
+        argparser argpars("executable", XEUS_CLING_VERSION, argparse::default_arguments::none);
         argpars.add_description("write executable");
         argpars.add_argument("filename")
             .help("filename")
@@ -52,6 +52,16 @@ namespace xcpp
         argpars.add_argument("options")
             .help("options")
             .default_value<std::vector<std::string>>({ "" });
+        // Add custom help (does not call `exit` avoiding to restart the kernel)
+        argpars.add_argument("-h", "--help")
+            .action([&](const std::string & /*unused*/)
+            {
+                std::cout << argpars.help().str();
+            })
+            .default_value(false)
+            .help("shows help message")
+            .implicit_value(true)
+            .nargs(0);
         return argpars;
     }
 

--- a/src/xmagics/execution.cpp
+++ b/src/xmagics/execution.cpp
@@ -35,7 +35,7 @@ namespace xcpp
 
     argparser timeit::get_options()
     {
-        argparser argpars("timeit");
+        argparser argpars("timeit", XEUS_CLING_VERSION, argparse::default_arguments::none);
         argpars.add_description("Time execution of a C++ statement or expression");
         argpars.add_argument("-n", "--number")
             .help("execute the given statement n times in a loop. If this value is not given, a fitting value is chosen")
@@ -52,6 +52,16 @@ namespace xcpp
         argpars.add_argument("expression")
             .help("expression to be evaluated")
             .remaining();
+        // Add custom help (does not call `exit` avoiding to restart the kernel)
+        argpars.add_argument("-h", "--help")
+            .action([&](const std::string & /*unused*/)
+            {
+                std::cout << argpars.help().str();
+            })
+            .default_value(false)
+            .help("shows help message")
+            .implicit_value(true)
+            .nargs(0);
         return argpars;
     }
 
@@ -112,7 +122,7 @@ namespace xcpp
         }
         catch (std::logic_error& e)
         {
-            if (trim(cell).empty())
+            if (trim(cell).empty() && (argpars["-h"] == false))
             {
                 std::cerr << "No expression given to evaluate" << std::endl;
             }

--- a/src/xmagics/os.cpp
+++ b/src/xmagics/os.cpp
@@ -22,7 +22,7 @@ namespace xcpp
 {
     argparser writefile::get_options()
     {
-        argparser argpars("file");
+        argparser argpars("file", XEUS_CLING_VERSION, argparse::default_arguments::none);
         argpars.add_description("write file");
         argpars.add_argument("-a", "--append")
             .help("append")
@@ -31,6 +31,16 @@ namespace xcpp
         argpars.add_argument("filename")
             .help("filename")
             .required();
+        // Add custom help (does not call `exit` avoiding to restart the kernel)
+        argpars.add_argument("-h", "--help")
+            .action([&](const std::string & /*unused*/)
+            {
+                std::cout << argpars.help().str();
+            })
+            .default_value(false)
+            .help("shows help message")
+            .implicit_value(true)
+            .nargs(0);
         return argpars;
     }
 


### PR DESCRIPTION
Add custom `help` for magic commands to avoid restarting the kernel. The default one implemented in `argparse` calls `exit` and makes the kernel restart.
For the same reason, and because it's not really relevant for magic commands, the default `version` argument was removed (we could still add it if we wish).
Two issues are a bit annoying when allowing to use `help` arguments:

- When the `magic command` requires at least one argument (case for `%%executable` and `%%file`), the implementation in `argparse` generates an error which shouldn't be displayed in this case. Cf. [argparse issue](https://github.com/p-ranav/argparse/issues/246).
- With the way `%%executable` and `%%file` magic commands are implemented in xeus-cling, having an empty cell after the first given line by the user is not possible. The following error is displayed:
`UsageError:  %%executable is a cell magic, but the cell body is empty.`
After giving it some thought, a local fix wouldn't be a good way to go since it will require to do some copies and add redundant code. So I think having this error asking to fill the cell (could be a line break) is better (or we could completely rethink the current implementation and regex/parsing cells/lines)...