### PR TITLE
Make xcpp*/kernel.json.in subsitution more portable

### DIFF
--- a/share/jupyter/kernels/xcpp11/kernel.json.in
+++ b/share/jupyter/kernels/xcpp11/kernel.json.in
@@ -1,7 +1,7 @@
 {
   "display_name": "C++11",
   "argv": [
-      "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/xcpp",
+      "@CMAKE_INSTALL_FULL_BINDIR@/xcpp",
       "-f",
       "{connection_file}",
       "-std=c++11"

--- a/share/jupyter/kernels/xcpp14/kernel.json.in
+++ b/share/jupyter/kernels/xcpp14/kernel.json.in
@@ -1,7 +1,7 @@
 {
   "display_name": "C++14",
   "argv": [
-      "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/xcpp",
+      "@CMAKE_INSTALL_FULL_BINDIR@/xcpp",
       "-f",
       "{connection_file}",
       "-std=c++14"

--- a/share/jupyter/kernels/xcpp17/kernel.json.in
+++ b/share/jupyter/kernels/xcpp17/kernel.json.in
@@ -1,7 +1,7 @@
 {
   "display_name": "C++17",
   "argv": [
-      "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/xcpp",
+      "@CMAKE_INSTALL_FULL_BINDIR@/xcpp",
       "-f",
       "{connection_file}",
       "-std=c++17"


### PR DESCRIPTION
According to https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

CMAKE_INSTALL_BINDIR can be either absolute or relative. Make sure we use the absolute value through CMAKE_INSTALL_FULL_BINDIR.