### PR TITLE
Adjust cling include path search according to dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,10 @@ if(MSVC)
     set_property(TARGET xeus-cling APPEND_STRING PROPERTY LINK_FLAGS ${cling_link_str})
 endif(MSVC)
 
+set(XEUS_SEARCH_PATH $<JOIN:$<TARGET_PROPERTY:xeus-cling,INCLUDE_DIRECTORIES>,:>)
+target_compile_definitions(xeus-cling PRIVATE "XEUS_SEARCH_PATH=\"${XEUS_SEARCH_PATH}\"")
+
+
 #########
 # Tests #
 #########

--- a/include/xeus-cling/xinterpreter.hpp
+++ b/include/xeus-cling/xinterpreter.hpp
@@ -70,6 +70,7 @@ namespace xcpp
         void redirect_output();
         void restore_output();
 
+        void init_extra_includes();
         void init_preamble();
         void init_magic();
 

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -53,6 +53,7 @@ namespace xcpp
           m_cerr_buffer(std::bind(&interpreter::publish_stderr, this, _1))
     {
         redirect_output();
+        init_extra_includes();
         init_preamble();
         init_magic();
     }
@@ -421,6 +422,11 @@ namespace xcpp
     void interpreter::publish_stderr(const std::string& s)
     {
         publish_stream("stderr", s);
+    }
+
+    void interpreter::init_extra_includes()
+    {
+        m_interpreter.AddIncludePaths(XEUS_SEARCH_PATH);
     }
 
     void interpreter::init_preamble()


### PR DESCRIPTION
If xeus and its dependencies are installed in non standard location, xeus-cling needs to be aware of the related include directories to be able to process xcpp extensions correctly.