### PR TITLE
Use runtime prefix path instead compile-time definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,10 +329,6 @@ if(MSVC)
     set_property(TARGET xeus-cling APPEND_STRING PROPERTY LINK_FLAGS ${cling_link_str})
 endif(MSVC)
 
-set(XEUS_SEARCH_PATH $<JOIN:$<TARGET_PROPERTY:xeus-cling,INCLUDE_DIRECTORIES>,:>)
-target_compile_definitions(xeus-cling PRIVATE "XEUS_SEARCH_PATH=\"${XEUS_SEARCH_PATH}\"")
-
-
 #########
 # Tests #
 #########

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -17,6 +17,8 @@
 
 #include <llvm/Support/DynamicLibrary.h>
 
+#include <xtl/xsystem.hpp>
+
 #include "xeus-cling/xbuffer.hpp"
 #include "xeus-cling/xeus_cling_config.hpp"
 #include "xeus-cling/xinterpreter.hpp"
@@ -428,7 +430,7 @@ namespace xcpp
 
     void interpreter::init_extra_includes()
     {
-        m_interpreter.AddIncludePaths(XEUS_SEARCH_PATH);
+        m_interpreter.AddIncludePaths(xtl::prefix_path() + "/include/");
     }
 
     void interpreter::init_preamble()


### PR DESCRIPTION
cc @serge-sans-paille - this may solve the last outstanding issue with xeus-cling on Nix.