### PR TITLE
Use both runtime and compile-time prefix paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,6 +329,10 @@ if(MSVC)
     set_property(TARGET xeus-cling APPEND_STRING PROPERTY LINK_FLAGS ${cling_link_str})
 endif(MSVC)
 
+set(XEUS_SEARCH_PATH $<JOIN:$<TARGET_PROPERTY:xeus-cling,INCLUDE_DIRECTORIES>,:>)
+target_compile_definitions(xeus-cling PRIVATE "XEUS_SEARCH_PATH=\"${XEUS_SEARCH_PATH}\"")
+
+
 #########
 # Tests #
 #########

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -431,6 +431,7 @@ namespace xcpp
     void interpreter::init_extra_includes()
     {
         m_interpreter.AddIncludePaths(xtl::prefix_path() + "/include/");
+        m_interpreter.AddIncludePaths(XEUS_SEARCH_PATH);
     }
 
     void interpreter::init_preamble()


### PR DESCRIPTION
Restores `XEUS_SEARCH_PATH` from
https://github.com/jupyter-xeus/xeus-cling/commit/76b276fbbd947856d0e72060fe19b95ce7fc6684.

We have an entry in `XEUS_SEARCH_PATH`(/build/xeus-cling/include) that does not exist at runtime, but shouldn't cause issues(hopefully).