### PR TITLE
Extra setup from cling.cpp

### DIFF
--- a/include/xeus-cling/xinterpreter.hpp
+++ b/include/xeus-cling/xinterpreter.hpp
@@ -72,6 +72,7 @@ namespace xcpp
         void restore_output();
 
         void init_extra_includes();
+        void init_libs();
         void init_preamble();
         void init_magic();
 

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -60,6 +60,7 @@ namespace xcpp
     {
         redirect_output();
         init_extra_includes();
+        init_libs();
         init_preamble();
         init_magic();
     }
@@ -432,6 +433,15 @@ namespace xcpp
     {
         m_interpreter.AddIncludePaths(xtl::prefix_path() + "/include/");
         m_interpreter.AddIncludePaths(XEUS_SEARCH_PATH);
+    }
+
+    void interpreter::init_libs()
+    {
+        const cling::InvocationOptions& Opts = m_interpreter.getOptions();
+        for (const std::string& Lib : Opts.LibsToLoad)
+        {
+            m_interpreter.loadFile(Lib);
+        }
     }
 
     void interpreter::init_preamble()


### PR DESCRIPTION
This is the successor to #361. Per some discussion in the QuantStack/Lobby matrix room.

This makes `-l` flags work with `xcpp` for me.